### PR TITLE
Update Astro site and base for portfolio deployment

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -3,9 +3,9 @@ import tailwindcss from '@tailwindcss/vite';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://rockem.github.io',
-	base: 'astro-photography-portfolio',
-	vite: {
-		plugins: [tailwindcss()],
-	},
+  site: 'https://codybingham.github.io',
+  base: '/portfolio/',
+  vite: {
+    plugins: [tailwindcss()],
+  },
 });


### PR DESCRIPTION
## Summary
- point the Astro site URL to https://codybingham.github.io for the GitHub Pages host
- set the base path to /portfolio/ so assets resolve under the repository name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df4dd450e4832f9d967459c58da0a5